### PR TITLE
SortedDict -> OrderedDict per django deprication warning, and 1.9 removal

### DIFF
--- a/django_remote_forms/fields.py
+++ b/django_remote_forms/fields.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.conf import settings
-from django.utils.datastructures import SortedDict
+from collections import OrderedDict
 
 from django_remote_forms import logger, widgets
 
@@ -24,7 +24,7 @@ class RemoteField(object):
         self.form_initial_data = form_initial_data
 
     def as_dict(self):
-        field_dict = SortedDict()
+        field_dict = OrderedDict()
         field_dict['title'] = self.field.__class__.__name__
         field_dict['required'] = self.field.required
         field_dict['label'] = self.field.label

--- a/django_remote_forms/forms.py
+++ b/django_remote_forms/forms.py
@@ -1,4 +1,4 @@
-from django.utils.datastructures import SortedDict
+from collections import OrderedDict
 from django import forms
 
 from django_remote_forms import fields, logger
@@ -102,7 +102,7 @@ class RemoteForm(object):
             }
         }
         """
-        form_dict = SortedDict()
+        form_dict = OrderedDict()
         if isinstance(self.form, forms.formsets.BaseFormSet):
             form_dict = self.get_formset_dict(self.form)
             return form_dict
@@ -111,7 +111,7 @@ class RemoteForm(object):
         form_dict['label_suffix'] = self.form.label_suffix
         form_dict['is_bound'] = self.form.is_bound
         form_dict['prefix'] = self.form.prefix
-        form_dict['fields'] = SortedDict()
+        form_dict['fields'] = OrderedDict()
         form_dict['errors'] = self.form.errors
         form_dict['fieldsets'] = getattr(self.form, 'fieldsets', [])
 

--- a/django_remote_forms/forms.py
+++ b/django_remote_forms/forms.py
@@ -43,7 +43,7 @@ class RemoteForm(object):
         self.excluded_fields |= (self.included_fields - self.all_fields)
 
         if not self.ordered_fields:
-            if self.form.fields.keyOrder:
+            if hasattr(self.form.fields, 'keyOrder'):
                 self.ordered_fields = self.form.fields.keyOrder
             else:
                 self.ordered_fields = self.form.fields.keys()

--- a/django_remote_forms/widgets.py
+++ b/django_remote_forms/widgets.py
@@ -111,9 +111,11 @@ class RemoteTimeInput(RemoteInput):
     def as_dict(self):
         widget_dict = super(RemoteTimeInput, self).as_dict()
 
+        manual_format = self.widget.format is None
+
         widget_dict['format'] = self.widget.format
-        widget_dict['manual_format'] = self.widget.manual_format
-        widget_dict['date'] = self.widget.manual_format
+        widget_dict['manual_format'] = manual_format
+        widget_dict['date'] = manual_format
         widget_dict['input_type'] = 'time'
 
         return widget_dict

--- a/django_remote_forms/widgets.py
+++ b/django_remote_forms/widgets.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.utils.dates import MONTHS
-from django.utils.datastructures import SortedDict
+from collections import OrderedDict
 
 
 class RemoteWidget(object):
@@ -10,7 +10,7 @@ class RemoteWidget(object):
         self.widget = widget
 
     def as_dict(self):
-        widget_dict = SortedDict()
+        widget_dict = OrderedDict()
         widget_dict['title'] = self.widget.__class__.__name__
         widget_dict['is_hidden'] = self.widget.is_hidden
         widget_dict['needs_multipart_form'] = self.widget.needs_multipart_form
@@ -195,7 +195,7 @@ class RemoteSelectMultiple(RemoteSelect):
 
 class RemoteRadioInput(RemoteWidget):
     def as_dict(self):
-        widget_dict = SortedDict()
+        widget_dict = OrderedDict()
         widget_dict['title'] = self.widget.__class__.__name__
         widget_dict['name'] = self.widget.name
         widget_dict['value'] = self.widget.value
@@ -210,7 +210,7 @@ class RemoteRadioInput(RemoteWidget):
 
 class RemoteRadioFieldRenderer(RemoteWidget):
     def as_dict(self):
-        widget_dict = SortedDict()
+        widget_dict = OrderedDict()
         widget_dict['title'] = self.widget.__class__.__name__
         widget_dict['name'] = self.widget.name
         widget_dict['value'] = self.widget.value


### PR DESCRIPTION
SortedDict is deprecated and will be removed in 1.9

Django docs indicate to use OrderedDict instead:

https://code.djangoproject.com/wiki/SortedDict
